### PR TITLE
Code quality fix - Local Variables should not be declared and then immediately returned or thrown.

### DIFF
--- a/src/main/java/com/mcac0006/siftscience/SiftScienceHelper.java
+++ b/src/main/java/com/mcac0006/siftscience/SiftScienceHelper.java
@@ -57,8 +57,7 @@ public class SiftScienceHelper {
 			final Builder request = target.request(MediaType.APPLICATION_JSON_TYPE);
 			final Response post = request.post(Entity.entity(serialize(event), MediaType.APPLICATION_JSON_TYPE));
 			
-			final SiftScienceResponse siftResult = deserializeResponse(post.readEntity(String.class));
-			return siftResult;
+			return deserializeResponse(post.readEntity(String.class));
 			
 		} catch (IOException e) {
 			throw new SiftScienceException("Error generating JSON content to send event.", e);
@@ -81,8 +80,7 @@ public class SiftScienceHelper {
 			final Builder request = target.request(MediaType.APPLICATION_JSON_TYPE);
 			final Response post = request.post(Entity.entity(serialize(label), MediaType.APPLICATION_JSON_TYPE));
 			
-			final SiftScienceResponse siftResult = deserializeResponse(post.readEntity(String.class));
-			return siftResult;
+			return deserializeResponse(post.readEntity(String.class));
 			
 		} catch (IOException e) {
 			throw new SiftScienceException("Error generating JSON content to send label.", e);
@@ -110,8 +108,7 @@ public class SiftScienceHelper {
 			final Builder request = target.request(MediaType.APPLICATION_JSON_TYPE);
 			final Response get = request.get();
 			
-			final SiftScienceScore score = deserializeScore(get.readEntity(String.class));
-			return score;
+			return deserializeScore(get.readEntity(String.class));
 			
 		} catch (IOException e) {
 			throw new RuntimeException("Error generating JSON content to retrieve score request.", e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.
 
Faisal Hameed