### PR TITLE
Code quality fix - "equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/src/main/java/com/mcac0006/siftscience/event/domain/AddItemToCart.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/AddItemToCart.java
@@ -78,43 +78,56 @@ public class AddItemToCart extends Event {
 		return this;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (!(obj instanceof AddItemToCart)) {
-			return false;
-		}
-		
-		final AddItemToCart aitc = (AddItemToCart)obj;
-		
-		if (this.item == null) {
-			if (aitc.getItem() != null) {
-				return false;
-			}
-		} else if (!this.item.equals(aitc.getItem())) {
-			return false;
-		}
-		
-		if (this.sessionId == null) {
-			if (aitc.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(aitc.getSessionId())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (aitc.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(aitc.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((item == null) ? 0 : item.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof AddItemToCart)) {
+            return false;
+        }
+        
+        final AddItemToCart aitc = (AddItemToCart)obj;
+        
+        if (this.item == null) {
+            if (aitc.getItem() != null) {
+                return false;
+            }
+        } else if (!this.item.equals(aitc.getItem())) {
+            return false;
+        }
+        
+        if (this.sessionId == null) {
+            if (aitc.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(aitc.getSessionId())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (aitc.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(aitc.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/CreateAccount.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/CreateAccount.java
@@ -183,93 +183,117 @@ public class CreateAccount extends Event {
 		this.socialSignOnType = socialSignOnType;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (obj == null || !(obj instanceof CreateAccount)) {
-			return false;
-		}
-		
-		final CreateAccount ca = (CreateAccount)obj;
-		
-		if (this.billingAddress == null) {
-			if (ca.getBillingAddress() != null) {
-				return false;
-			}
-		} else if (!this.billingAddress.equals(ca.getBillingAddress())) {
-			return false;
-		}
-		
-		if (this.name == null) {
-			if (ca.getName() != null) {
-				return false;
-			}
-		} else if (!this.name.equals(ca.getName())) {
-			return false;
-		}
-		
-		if (this.paymentMethods == null) {
-			if (ca.getPaymentMethods() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.paymentMethods, ca.getPaymentMethods())) {
-			return false;
-		}
-		
-		if (this.phone == null) {
-			if (ca.getPhone() != null) {
-				return false;
-			}
-		} else if (!this.phone.equals(ca.getPhone())) {
-			return false;
-		}
-		
-		if (this.referrerUserId == null) {
-			if (ca.getReferrerUserId() != null) {
-				return false;
-			}
-		} else if (!this.referrerUserId.equals(ca.getReferrerUserId())) {
-			return false;
-		}
-		
-		if (this.sessionId == null) {
-			if (ca.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(ca.getSessionId())) {
-			return false;
-		}
-		
-		if (this.socialSignOnType == null) {
-			if (ca.getSocialSignOnType() != null) {
-				return false;
-			}
-		} else if (!this.socialSignOnType.equals(ca.getSocialSignOnType())) {
-			return false;
-		}
-		
-		if (this.userEmail == null) {
-			if (ca.getUserEmail() != null) {
-				return false;
-			}
-		} else if (!this.userEmail.equals(ca.getUserEmail())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (ca.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(ca.getUserId())) {
-			return false;
-		}
-		
-		return true;
-		
-	}
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((billingAddress == null) ? 0 : billingAddress.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + Arrays.hashCode(paymentMethods);
+        result = prime * result + ((phone == null) ? 0 : phone.hashCode());
+        result = prime * result
+                + ((referrerUserId == null) ? 0 : referrerUserId.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime
+                * result
+                + ((socialSignOnType == null) ? 0 : socialSignOnType.hashCode());
+        result = prime * result
+                + ((userEmail == null) ? 0 : userEmail.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof CreateAccount)) {
+            return false;
+        }
+        
+        final CreateAccount ca = (CreateAccount)obj;
+        
+        if (this.billingAddress == null) {
+            if (ca.getBillingAddress() != null) {
+                return false;
+            }
+        } else if (!this.billingAddress.equals(ca.getBillingAddress())) {
+            return false;
+        }
+        
+        if (this.name == null) {
+            if (ca.getName() != null) {
+                return false;
+            }
+        } else if (!this.name.equals(ca.getName())) {
+            return false;
+        }
+        
+        if (this.paymentMethods == null) {
+            if (ca.getPaymentMethods() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.paymentMethods, ca.getPaymentMethods())) {
+            return false;
+        }
+        
+        if (this.phone == null) {
+            if (ca.getPhone() != null) {
+                return false;
+            }
+        } else if (!this.phone.equals(ca.getPhone())) {
+            return false;
+        }
+        
+        if (this.referrerUserId == null) {
+            if (ca.getReferrerUserId() != null) {
+                return false;
+            }
+        } else if (!this.referrerUserId.equals(ca.getReferrerUserId())) {
+            return false;
+        }
+        
+        if (this.sessionId == null) {
+            if (ca.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(ca.getSessionId())) {
+            return false;
+        }
+        
+        if (this.socialSignOnType == null) {
+            if (ca.getSocialSignOnType() != null) {
+                return false;
+            }
+        } else if (!this.socialSignOnType.equals(ca.getSocialSignOnType())) {
+            return false;
+        }
+        
+        if (this.userEmail == null) {
+            if (ca.getUserEmail() != null) {
+                return false;
+            }
+        } else if (!this.userEmail.equals(ca.getUserEmail())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (ca.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(ca.getUserId())) {
+            return false;
+        }
+        
+        return true;
+        
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/CreateOrder.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/CreateOrder.java
@@ -234,116 +234,145 @@ public class CreateOrder extends Event {
 	public String getSellerUserId() {
 		return sellerUserId;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (obj == null || !(obj instanceof CreateOrder)) {
-			return false;
-		}
-		
-		final CreateOrder co = (CreateOrder)obj;
-		
-		if (this.expeditedShipping == null) {
-			if (co.getExpeditedShipping() != null) {
-				return false;
-			}
-		} else if (!this.expeditedShipping.equals(co.getExpeditedShipping())) {
-			return false;
-		}
-		
-		if (this.amount == null) {
-			if (co.getAmount() != null) {
-				return false;
-			}
-		} else if (!this.amount.equals(co.getAmount())) {
-			return false;
-		}
-		
-		if (this.billingAddress == null) {
-			if (co.getBillingAddress() != null) {
-				return false;
-			}
-		} else if (!this.billingAddress.equals(co.getBillingAddress())) {
-			return false;
-		}
-		
-		if (this.currencyCode == null) {
-			if (co.getCurrencyCode() != null) {
-				return false;
-			}
-		} else if (!this.currencyCode.equals(co.getCurrencyCode())) {
-			return false;
-		}
-		
-		if (this.items == null) {
-			if (co.getItems() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.items, co.getItems())) {
-			return false;
-		}
-		
-		if (this.orderId == null) {
-			if (co.getOrderId() != null) {
-				return false;
-			}
-		} else if (!this.orderId.equals(co.getOrderId())) {
-			return false;
-		}
-		
-		if (this.paymentMethods == null) {
-			if (co.getPaymentMethods() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.paymentMethods, co.getPaymentMethods())) {
-			return false;
-		}
-		
-		if (this.sellerUserId == null) {
-			if (co.getSellerUserId() != null) {
-				return false;
-			}
-		} else if (!this.sellerUserId.equals(co.getSellerUserId())) {
-			return false;
-		}
-		
-		if (this.sessionId == null) {
-			if (co.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(co.getSessionId())) {
-			return false;
-		}
-		
-		if (this.shippingAddress == null) {
-			if (co.getShippingAddress() != null) {
-				return false;
-			}
-		} else if (!this.shippingAddress.equals(co.getShippingAddress())) {
-			return false;
-		}
-		
-		if (this.userEmail == null) {
-			if (co.getUserEmail() != null) {
-				return false;
-			}
-		} else if (!this.userEmail.equals(co.getUserEmail())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (co.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(co.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((amount == null) ? 0 : amount.hashCode());
+        result = prime * result
+                + ((billingAddress == null) ? 0 : billingAddress.hashCode());
+        result = prime * result
+                + ((currencyCode == null) ? 0 : currencyCode.hashCode());
+        result = prime
+                * result
+                + ((expeditedShipping == null) ? 0 : expeditedShipping
+                        .hashCode());
+        result = prime * result + Arrays.hashCode(items);
+        result = prime * result + ((orderId == null) ? 0 : orderId.hashCode());
+        result = prime * result + Arrays.hashCode(paymentMethods);
+        result = prime * result
+                + ((sellerUserId == null) ? 0 : sellerUserId.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result
+                + ((shippingAddress == null) ? 0 : shippingAddress.hashCode());
+        result = prime * result
+                + ((userEmail == null) ? 0 : userEmail.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof CreateOrder)) {
+            return false;
+        }
+        
+        final CreateOrder co = (CreateOrder)obj;
+        
+        if (this.expeditedShipping == null) {
+            if (co.getExpeditedShipping() != null) {
+                return false;
+            }
+        } else if (!this.expeditedShipping.equals(co.getExpeditedShipping())) {
+            return false;
+        }
+        
+        if (this.amount == null) {
+            if (co.getAmount() != null) {
+                return false;
+            }
+        } else if (!this.amount.equals(co.getAmount())) {
+            return false;
+        }
+        
+        if (this.billingAddress == null) {
+            if (co.getBillingAddress() != null) {
+                return false;
+            }
+        } else if (!this.billingAddress.equals(co.getBillingAddress())) {
+            return false;
+        }
+        
+        if (this.currencyCode == null) {
+            if (co.getCurrencyCode() != null) {
+                return false;
+            }
+        } else if (!this.currencyCode.equals(co.getCurrencyCode())) {
+            return false;
+        }
+        
+        if (this.items == null) {
+            if (co.getItems() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.items, co.getItems())) {
+            return false;
+        }
+        
+        if (this.orderId == null) {
+            if (co.getOrderId() != null) {
+                return false;
+            }
+        } else if (!this.orderId.equals(co.getOrderId())) {
+            return false;
+        }
+        
+        if (this.paymentMethods == null) {
+            if (co.getPaymentMethods() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.paymentMethods, co.getPaymentMethods())) {
+            return false;
+        }
+        
+        if (this.sellerUserId == null) {
+            if (co.getSellerUserId() != null) {
+                return false;
+            }
+        } else if (!this.sellerUserId.equals(co.getSellerUserId())) {
+            return false;
+        }
+        
+        if (this.sessionId == null) {
+            if (co.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(co.getSessionId())) {
+            return false;
+        }
+        
+        if (this.shippingAddress == null) {
+            if (co.getShippingAddress() != null) {
+                return false;
+            }
+        } else if (!this.shippingAddress.equals(co.getShippingAddress())) {
+            return false;
+        }
+        
+        if (this.userEmail == null) {
+            if (co.getUserEmail() != null) {
+                return false;
+            }
+        } else if (!this.userEmail.equals(co.getUserEmail())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (co.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(co.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/Event.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/Event.java
@@ -117,47 +117,61 @@ public abstract class Event {
 		this.time = time;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((apiKey == null) ? 0 : apiKey.hashCode());
+        result = prime * result
+                + ((customFields == null) ? 0 : customFields.hashCode());
+        result = prime * result
+                + ((eventType == null) ? 0 : eventType.hashCode());
+        result = prime * result + ((time == null) ? 0 : time.hashCode());
+        return result;
+    }
 
-		if (obj == null || !(obj instanceof Event)) {
-			return false;
-		}
-		
-		final Event e = (Event)obj;
-		
-		if (this.apiKey == null) {
-			if (e.getApiKey() != null) {
-				return false;
-			}
-		} else if (!this.apiKey.equals(e.getApiKey())) {
-			return false;
-		}
-		
-		if (this.eventType == null) {
-			if (e.getEventType() != null) {
-				return false;
-			}
-		} else if (!this.eventType.equals(e.getEventType())) {
-			return false;
-		}
-		
-		if (this.customFields == null) {
-			if (e.getCustomFields() != null) {
-				return false;
-			}
-		} else if (!this.customFields.equals(e.getCustomFields())) {
-			return false;
-		}
-		
-		if (this.time == null) {
-			if (e.getTime() != null) {
-				return false;
-			}
-		} else if (!this.time.equals(e.getTime())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof Event)) {
+            return false;
+        }
+        
+        final Event e = (Event)obj;
+        
+        if (this.apiKey == null) {
+            if (e.getApiKey() != null) {
+                return false;
+            }
+        } else if (!this.apiKey.equals(e.getApiKey())) {
+            return false;
+        }
+        
+        if (this.eventType == null) {
+            if (e.getEventType() != null) {
+                return false;
+            }
+        } else if (!this.eventType.equals(e.getEventType())) {
+            return false;
+        }
+        
+        if (this.customFields == null) {
+            if (e.getCustomFields() != null) {
+                return false;
+            }
+        } else if (!this.customFields.equals(e.getCustomFields())) {
+            return false;
+        }
+        
+        if (this.time == null) {
+            if (e.getTime() != null) {
+                return false;
+            }
+        } else if (!this.time.equals(e.getTime())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/LinkSessionToUser.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/LinkSessionToUser.java
@@ -50,37 +50,47 @@ public class LinkSessionToUser extends Event {
 		this.userId = userId;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (!(obj instanceof LinkSessionToUser)) {
-			return false;
-		}
-		
-		final LinkSessionToUser lstu = (LinkSessionToUser)obj;
-		
-		if (this.sessionId == null) {
-			if (lstu.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(lstu.getSessionId())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (lstu.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(lstu.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof LinkSessionToUser)) {
+            return false;
+        }
+        
+        final LinkSessionToUser lstu = (LinkSessionToUser)obj;
+        
+        if (this.sessionId == null) {
+            if (lstu.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(lstu.getSessionId())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (lstu.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(lstu.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
 
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/Login.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/Login.java
@@ -74,43 +74,57 @@ public class Login extends Event {
 		return this;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (!(obj instanceof Login)) {
-			return false;
-		}
-		
-		final Login l = (Login)obj;
-		
-		if (this.loginStatus == null) {
-			if (l.getLoginStatus() != null) {
-				return false;
-			}
-		} else if (!this.loginStatus.equals(l.getLoginStatus())) {
-			return false;
-		}
-		
-		if (this.sessionId == null) {
-			if (l.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(l.getSessionId())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (l.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(l.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result
+                + ((loginStatus == null) ? 0 : loginStatus.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof Login)) {
+            return false;
+        }
+        
+        final Login l = (Login)obj;
+        
+        if (this.loginStatus == null) {
+            if (l.getLoginStatus() != null) {
+                return false;
+            }
+        } else if (!this.loginStatus.equals(l.getLoginStatus())) {
+            return false;
+        }
+        
+        if (this.sessionId == null) {
+            if (l.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(l.getSessionId())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (l.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(l.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
+
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/Logout.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/Logout.java
@@ -36,29 +36,38 @@ public class Logout extends Event {
 		this.userId = userId;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (!(obj instanceof Logout)) {
-			return false;
-		}
-		
-		final Logout l = (Logout)obj;
-		
-		if (this.userId == null) {
-			if (l.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(l.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof Logout)) {
+            return false;
+        }
+        
+        final Logout l = (Logout)obj;
+        
+        if (this.userId == null) {
+            if (l.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(l.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
 
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/RemoveItemFromCart.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/RemoveItemFromCart.java
@@ -74,43 +74,56 @@ public class RemoveItemFromCart extends Event {
 		return this;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (!(obj instanceof RemoveItemFromCart)) {
-			return false;
-		}
-		
-		final RemoveItemFromCart rifc = (RemoveItemFromCart)obj;
-		
-		if (this.item == null) {
-			if (rifc.getItem() != null) {
-				return false;
-			}
-		} else if (!this.item.equals(rifc.getItem())) {
-			return false;
-		}
-		
-		if (this.sessionId == null) {
-			if (rifc.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(rifc.getSessionId())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (rifc.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(rifc.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((item == null) ? 0 : item.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof RemoveItemFromCart)) {
+            return false;
+        }
+        
+        final RemoveItemFromCart rifc = (RemoveItemFromCart)obj;
+        
+        if (this.item == null) {
+            if (rifc.getItem() != null) {
+                return false;
+            }
+        } else if (!this.item.equals(rifc.getItem())) {
+            return false;
+        }
+        
+        if (this.sessionId == null) {
+            if (rifc.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(rifc.getSessionId())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (rifc.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(rifc.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
+
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/SendMessage.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/SendMessage.java
@@ -105,60 +105,74 @@ public class SendMessage extends Event {
 		return this;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((content == null) ? 0 : content.hashCode());
+        result = prime * result
+                + ((recipientUserId == null) ? 0 : recipientUserId.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result + ((subject == null) ? 0 : subject.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
 
-		if (!(obj instanceof SendMessage)) {
-			return false;
-		}
-		
-		final SendMessage rm = (SendMessage)obj;
-		
-		if (this.sessionId == null) {
-			if (rm.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(rm.getSessionId())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (rm.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(rm.getUserId())) {
-			return false;
-		}
-		
-		if (this.content == null) {
-			if (rm.getContent() != null) {
-				return false;
-			}
-		} else if (!this.content.equals(rm.getContent())) {
-			return false;
-		}
-		
-		if (this.recipientUserId == null) {
-			if (rm.getRecipientUserId() != null) {
-				return false;
-			}
-		} else if (!this.recipientUserId.equals(rm.getRecipientUserId())) {
-			return false;
-		}
-		
-		if (this.subject == null) {
-			if (rm.getSubject() != null) {
-				return false;
-			}
-		} else if (!this.subject.equals(rm.getSubject())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof SendMessage)) {
+            return false;
+        }
+        
+        final SendMessage rm = (SendMessage)obj;
+        
+        if (this.sessionId == null) {
+            if (rm.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(rm.getSessionId())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (rm.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(rm.getUserId())) {
+            return false;
+        }
+        
+        if (this.content == null) {
+            if (rm.getContent() != null) {
+                return false;
+            }
+        } else if (!this.content.equals(rm.getContent())) {
+            return false;
+        }
+        
+        if (this.recipientUserId == null) {
+            if (rm.getRecipientUserId() != null) {
+                return false;
+            }
+        } else if (!this.recipientUserId.equals(rm.getRecipientUserId())) {
+            return false;
+        }
+        
+        if (this.subject == null) {
+            if (rm.getSubject() != null) {
+                return false;
+            }
+        } else if (!this.subject.equals(rm.getSubject())) {
+            return false;
+        }
+        
+        return true;
+    }
 
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/SubmitReview.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/SubmitReview.java
@@ -130,75 +130,95 @@ public class SubmitReview extends Event {
 		return this;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((content == null) ? 0 : content.hashCode());
+        result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+        result = prime * result
+                + ((reviewTitle == null) ? 0 : reviewTitle.hashCode());
+        result = prime * result
+                + ((reviewedUserId == null) ? 0 : reviewedUserId.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime
+                * result
+                + ((submissionStatus == null) ? 0 : submissionStatus.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
 
-		if (!(obj instanceof SubmitReview)) {
-			return false;
-		}
-		
-		final SubmitReview sr = (SubmitReview)obj;
-		
-		if (this.sessionId == null) {
-			if (sr.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(sr.getSessionId())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (sr.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(sr.getUserId())) {
-			return false;
-		}
-		
-		if (this.content == null) {
-			if (sr.getContent() != null) {
-				return false;
-			}
-		} else if (!this.content.equals(sr.getContent())) {
-			return false;
-		}
-		
-		if (this.itemId == null) {
-			if (sr.getItemId() != null) {
-				return false;
-			}
-		} else if (!this.itemId.equals(sr.getItemId())) {
-			return false;
-		}
-		
-		if (this.reviewedUserId == null) {
-			if (sr.getReviewedUserId() != null) {
-				return false;
-			}
-		} else if (!this.reviewedUserId.equals(sr.getReviewedUserId())) {
-			return false;
-		}
-		
-		if (this.reviewTitle == null) {
-			if (sr.getReviewTitle() != null) {
-				return false;
-			}
-		} else if (!this.reviewTitle.equals(sr.getReviewTitle())) {
-			return false;
-		}
-		
-		if (this.submissionStatus == null) {
-			if (sr.getSubmissionStatus() != null) {
-				return false;
-			}
-		} else if (!this.submissionStatus.equals(sr.getSubmissionStatus())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof SubmitReview)) {
+            return false;
+        }
+        
+        final SubmitReview sr = (SubmitReview)obj;
+        
+        if (this.sessionId == null) {
+            if (sr.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(sr.getSessionId())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (sr.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(sr.getUserId())) {
+            return false;
+        }
+        
+        if (this.content == null) {
+            if (sr.getContent() != null) {
+                return false;
+            }
+        } else if (!this.content.equals(sr.getContent())) {
+            return false;
+        }
+        
+        if (this.itemId == null) {
+            if (sr.getItemId() != null) {
+                return false;
+            }
+        } else if (!this.itemId.equals(sr.getItemId())) {
+            return false;
+        }
+        
+        if (this.reviewedUserId == null) {
+            if (sr.getReviewedUserId() != null) {
+                return false;
+            }
+        } else if (!this.reviewedUserId.equals(sr.getReviewedUserId())) {
+            return false;
+        }
+        
+        if (this.reviewTitle == null) {
+            if (sr.getReviewTitle() != null) {
+                return false;
+            }
+        } else if (!this.reviewTitle.equals(sr.getReviewTitle())) {
+            return false;
+        }
+        
+        if (this.submissionStatus == null) {
+            if (sr.getSubmissionStatus() != null) {
+                return false;
+            }
+        } else if (!this.submissionStatus.equals(sr.getSubmissionStatus())) {
+            return false;
+        }
+        
+        return true;
+    }
+
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/Transaction.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/Transaction.java
@@ -232,125 +232,157 @@ public class Transaction extends Event {
 		this.sellerUserId = sellerUserId;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (obj == null || !(obj instanceof Transaction)) {
-			return false;
-		}
-		
-		final Transaction tx = (Transaction)obj;
-		
-		if (this.amount == null) {
-			if (tx.getAmount() != null) {
-				return false;
-			}
-		} else if (!this.amount.equals(tx.getAmount())) {
-			return false;
-		}
-		
-		if (this.billingAddress == null) {
-			if (tx.getBillingAddress() != null) {
-				return false;
-			}
-		} else if (!this.billingAddress.equals(tx.getBillingAddress())) {
-			return false;
-		}
-		
-		if (this.currencyCode == null) {
-			if (tx.getCurrencyCode() != null) {
-				return false;
-			}
-		} else if (!this.currencyCode.equals(tx.getCurrencyCode())) {
-			return false;
-		}
-		
-		if (this.orderId == null) {
-			if (tx.getOrderId() != null) {
-				return false;
-			}
-		} else if (!this.orderId.equals(tx.getOrderId())) {
-			return false;
-		}
-		
-		if (this.paymentMethod == null) {
-			if (tx.getPaymentMethod() != null) {
-				return false;
-			}
-		} else if (!this.paymentMethod.equals(tx.getPaymentMethod())) {
-			return false;
-		}
-		
-		if (this.sellerUserId == null) {
-			if (tx.getSellerUserId() != null) {
-				return false;
-			}
-		} else if (!this.sellerUserId.equals(tx.getSellerUserId())) {
-			return false;
-		}
-		
-		if (this.sessionId == null) {
-			if (tx.getSessionId() != null) {
-				return false;
-			}
-		} else if (!this.sessionId.equals(tx.getSessionId())) {
-			return false;
-		}
-		
-		if (this.shippingAddress == null) {
-			if (tx.getShippingAddress() != null) {
-				return false;
-			}
-		} else if (!this.shippingAddress.equals(tx.getShippingAddress())) {
-			return false;
-		}
-		
-		if (this.transactionId == null) {
-			if (tx.getTransactionId() != null) {
-				return false;
-			}
-		} else if (!this.transactionId.equals(tx.getTransactionId())) {
-			return false;
-		}
-		
-		if (this.transactionStatus == null) {
-			if (tx.getTransactionStatus() != null) {
-				return false;
-			}
-		} else if (!this.transactionStatus.equals(tx.getTransactionStatus())) {
-			return false;
-		}
-		
-		if (this.transactionType == null) {
-			if (tx.getTransactionType() != null) {
-				return false;
-			}
-		} else if (!this.transactionType.equals(tx.getTransactionType())) {
-			return false;
-		}
-		
-		if (this.userEmail == null) {
-			if (tx.getUserEmail() != null) {
-				return false;
-			}
-		} else if (!this.userEmail.equals(tx.getUserEmail())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (tx.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(tx.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((amount == null) ? 0 : amount.hashCode());
+        result = prime * result
+                + ((billingAddress == null) ? 0 : billingAddress.hashCode());
+        result = prime * result
+                + ((currencyCode == null) ? 0 : currencyCode.hashCode());
+        result = prime * result + ((orderId == null) ? 0 : orderId.hashCode());
+        result = prime * result
+                + ((paymentMethod == null) ? 0 : paymentMethod.hashCode());
+        result = prime * result
+                + ((sellerUserId == null) ? 0 : sellerUserId.hashCode());
+        result = prime * result
+                + ((sessionId == null) ? 0 : sessionId.hashCode());
+        result = prime * result
+                + ((shippingAddress == null) ? 0 : shippingAddress.hashCode());
+        result = prime * result
+                + ((transactionId == null) ? 0 : transactionId.hashCode());
+        result = prime
+                * result
+                + ((transactionStatus == null) ? 0 : transactionStatus
+                        .hashCode());
+        result = prime * result
+                + ((transactionType == null) ? 0 : transactionType.hashCode());
+        result = prime * result
+                + ((userEmail == null) ? 0 : userEmail.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof Transaction)) {
+            return false;
+        }
+        
+        final Transaction tx = (Transaction)obj;
+        
+        if (this.amount == null) {
+            if (tx.getAmount() != null) {
+                return false;
+            }
+        } else if (!this.amount.equals(tx.getAmount())) {
+            return false;
+        }
+        
+        if (this.billingAddress == null) {
+            if (tx.getBillingAddress() != null) {
+                return false;
+            }
+        } else if (!this.billingAddress.equals(tx.getBillingAddress())) {
+            return false;
+        }
+        
+        if (this.currencyCode == null) {
+            if (tx.getCurrencyCode() != null) {
+                return false;
+            }
+        } else if (!this.currencyCode.equals(tx.getCurrencyCode())) {
+            return false;
+        }
+        
+        if (this.orderId == null) {
+            if (tx.getOrderId() != null) {
+                return false;
+            }
+        } else if (!this.orderId.equals(tx.getOrderId())) {
+            return false;
+        }
+        
+        if (this.paymentMethod == null) {
+            if (tx.getPaymentMethod() != null) {
+                return false;
+            }
+        } else if (!this.paymentMethod.equals(tx.getPaymentMethod())) {
+            return false;
+        }
+        
+        if (this.sellerUserId == null) {
+            if (tx.getSellerUserId() != null) {
+                return false;
+            }
+        } else if (!this.sellerUserId.equals(tx.getSellerUserId())) {
+            return false;
+        }
+        
+        if (this.sessionId == null) {
+            if (tx.getSessionId() != null) {
+                return false;
+            }
+        } else if (!this.sessionId.equals(tx.getSessionId())) {
+            return false;
+        }
+        
+        if (this.shippingAddress == null) {
+            if (tx.getShippingAddress() != null) {
+                return false;
+            }
+        } else if (!this.shippingAddress.equals(tx.getShippingAddress())) {
+            return false;
+        }
+        
+        if (this.transactionId == null) {
+            if (tx.getTransactionId() != null) {
+                return false;
+            }
+        } else if (!this.transactionId.equals(tx.getTransactionId())) {
+            return false;
+        }
+        
+        if (this.transactionStatus == null) {
+            if (tx.getTransactionStatus() != null) {
+                return false;
+            }
+        } else if (!this.transactionStatus.equals(tx.getTransactionStatus())) {
+            return false;
+        }
+        
+        if (this.transactionType == null) {
+            if (tx.getTransactionType() != null) {
+                return false;
+            }
+        } else if (!this.transactionType.equals(tx.getTransactionType())) {
+            return false;
+        }
+        
+        if (this.userEmail == null) {
+            if (tx.getUserEmail() != null) {
+                return false;
+            }
+        } else if (!this.userEmail.equals(tx.getUserEmail())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (tx.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(tx.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
 
 }

--- a/src/main/java/com/mcac0006/siftscience/event/domain/UpdateAccount.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/UpdateAccount.java
@@ -204,100 +204,124 @@ public class UpdateAccount extends Event {
 		return this;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		
-		if (!super.equals(obj)) {
-			return false;
-		}
 
-		if (obj == null || !(obj instanceof UpdateAccount)) {
-			return false;
-		}
-		
-		final UpdateAccount ua = (UpdateAccount)obj;
-		
-		if (this.billingAddress == null) {
-			if (ua.getBillingAddress() != null) {
-				return false;
-			}
-		} else if (!this.billingAddress.equals(ua.getBillingAddress())) {
-			return false;
-		}
-		
-		if (this.name == null) {
-			if (ua.getName() != null) {
-				return false;
-			}
-		} else if (!this.name.equals(ua.getName())) {
-			return false;
-		}
-		
-		if (this.paymentMethods == null) {
-			if (ua.getPaymentMethods() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.paymentMethods, ua.getPaymentMethods())) {
-			return false;
-		}
-		
-		if (this.phone == null) {
-			if (ua.getPhone() != null) {
-				return false;
-			}
-		} else if (!this.phone.equals(ua.getPhone())) {
-			return false;
-		}
-		
-		if (this.referrerUserId == null) {
-			if (ua.getReferrerUserId() != null) {
-				return false;
-			}
-		} else if (!this.referrerUserId.equals(ua.getReferrerUserId())) {
-			return false;
-		}
-		
-		if (this.socialSignOnType == null) {
-			if (ua.getSocialSignOnType() != null) {
-				return false;
-			}
-		} else if (!this.socialSignOnType.equals(ua.getSocialSignOnType())) {
-			return false;
-		}
-		
-		if (this.userEmail == null) {
-			if (ua.getUserEmail() != null) {
-				return false;
-			}
-		} else if (!this.userEmail.equals(ua.getUserEmail())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (ua.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(ua.getUserId())) {
-			return false;
-		}
-		
-		if (this.changedPassword == null) {
-			if (ua.getChangedPassword() != null) {
-				return false;
-			}
-		} else if (!this.changedPassword.equals(ua.getChangedPassword())) {
-			return false;
-		}
-		
-		if (this.socialSignOnType == null) {
-			if (ua.getSocialSignOnType() != null) {
-				return false;
-			}
-		} else if (!this.socialSignOnType.equals(ua.getSocialSignOnType())) {
-			return false;
-		}
-		
-		return true;
-		
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result
+                + ((billingAddress == null) ? 0 : billingAddress.hashCode());
+        result = prime * result
+                + ((changedPassword == null) ? 0 : changedPassword.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + Arrays.hashCode(paymentMethods);
+        result = prime * result + ((phone == null) ? 0 : phone.hashCode());
+        result = prime * result
+                + ((referrerUserId == null) ? 0 : referrerUserId.hashCode());
+        result = prime
+                * result
+                + ((socialSignOnType == null) ? 0 : socialSignOnType.hashCode());
+        result = prime * result
+                + ((userEmail == null) ? 0 : userEmail.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        
+        if (!super.equals(obj)) {
+            return false;
+        }
+
+        if (obj == null || !(obj instanceof UpdateAccount)) {
+            return false;
+        }
+        
+        final UpdateAccount ua = (UpdateAccount)obj;
+        
+        if (this.billingAddress == null) {
+            if (ua.getBillingAddress() != null) {
+                return false;
+            }
+        } else if (!this.billingAddress.equals(ua.getBillingAddress())) {
+            return false;
+        }
+        
+        if (this.name == null) {
+            if (ua.getName() != null) {
+                return false;
+            }
+        } else if (!this.name.equals(ua.getName())) {
+            return false;
+        }
+        
+        if (this.paymentMethods == null) {
+            if (ua.getPaymentMethods() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.paymentMethods, ua.getPaymentMethods())) {
+            return false;
+        }
+        
+        if (this.phone == null) {
+            if (ua.getPhone() != null) {
+                return false;
+            }
+        } else if (!this.phone.equals(ua.getPhone())) {
+            return false;
+        }
+        
+        if (this.referrerUserId == null) {
+            if (ua.getReferrerUserId() != null) {
+                return false;
+            }
+        } else if (!this.referrerUserId.equals(ua.getReferrerUserId())) {
+            return false;
+        }
+        
+        if (this.socialSignOnType == null) {
+            if (ua.getSocialSignOnType() != null) {
+                return false;
+            }
+        } else if (!this.socialSignOnType.equals(ua.getSocialSignOnType())) {
+            return false;
+        }
+        
+        if (this.userEmail == null) {
+            if (ua.getUserEmail() != null) {
+                return false;
+            }
+        } else if (!this.userEmail.equals(ua.getUserEmail())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (ua.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(ua.getUserId())) {
+            return false;
+        }
+        
+        if (this.changedPassword == null) {
+            if (ua.getChangedPassword() != null) {
+                return false;
+            }
+        } else if (!this.changedPassword.equals(ua.getChangedPassword())) {
+            return false;
+        }
+        
+        if (this.socialSignOnType == null) {
+            if (ua.getSocialSignOnType() != null) {
+                return false;
+            }
+        } else if (!this.socialSignOnType.equals(ua.getSocialSignOnType())) {
+            return false;
+        }
+        
+        return true;
+        
+    }
+
 }

--- a/src/main/java/com/mcac0006/siftscience/label/domain/Label.java
+++ b/src/main/java/com/mcac0006/siftscience/label/domain/Label.java
@@ -110,55 +110,69 @@ public class Label {
 		this.time = time;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((apiKey == null) ? 0 : apiKey.hashCode());
+        result = prime * result
+                + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((isBad == null) ? 0 : isBad.hashCode());
+        result = prime * result + Arrays.hashCode(reasons);
+        result = prime * result + ((time == null) ? 0 : time.hashCode());
+        return result;
+    }
 
-		if (obj == null || !(obj instanceof Label)) {
-			return false;
-		}
-		
-		final Label l = (Label)obj;
-		
-		if (this.isBad == null) {
-			if (l.getIsBad() != null) {
-				return false;
-			}
-		} else if (!this.isBad.equals(l.getIsBad())) {
-			return false;
-		}
-		
-		if (this.apiKey == null) {
-			if (l.getApiKey() != null) {
-				return false;
-			}
-		} else if (!this.apiKey.equals(l.getApiKey())) {
-			return false;
-		}
-		
-		if (this.description == null) {
-			if (l.getDescription() != null) {
-				return false;
-			}
-		} else if (!this.description.equals(l.getDescription())) {
-			return false;
-		}
-		
-		if (this.reasons == null) {
-			if (l.getReasons() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.reasons, l.getReasons())) {
-			return false;
-		}
-		
-		if (this.time == null) {
-			if (l.getTime() != null) {
-				return false;
-			}
-		} else if (!this.time.equals(l.getTime())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof Label)) {
+            return false;
+        }
+        
+        final Label l = (Label)obj;
+        
+        if (this.isBad == null) {
+            if (l.getIsBad() != null) {
+                return false;
+            }
+        } else if (!this.isBad.equals(l.getIsBad())) {
+            return false;
+        }
+        
+        if (this.apiKey == null) {
+            if (l.getApiKey() != null) {
+                return false;
+            }
+        } else if (!this.apiKey.equals(l.getApiKey())) {
+            return false;
+        }
+        
+        if (this.description == null) {
+            if (l.getDescription() != null) {
+                return false;
+            }
+        } else if (!this.description.equals(l.getDescription())) {
+            return false;
+        }
+        
+        if (this.reasons == null) {
+            if (l.getReasons() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.reasons, l.getReasons())) {
+            return false;
+        }
+        
+        if (this.time == null) {
+            if (l.getTime() != null) {
+                return false;
+            }
+        } else if (!this.time.equals(l.getTime())) {
+            return false;
+        }
+        
+        return true;
+    }
+
 }

--- a/src/main/java/com/mcac0006/siftscience/score/domain/Label.java
+++ b/src/main/java/com/mcac0006/siftscience/score/domain/Label.java
@@ -96,47 +96,60 @@ public class Label {
 		this.time = time;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((isBad == null) ? 0 : isBad.hashCode());
+        result = prime * result + Arrays.hashCode(reasons);
+        result = prime * result + ((time == null) ? 0 : time.hashCode());
+        return result;
+    }
 
-		if (obj == null || !(obj instanceof Label)) {
-			return false;
-		}
-		
-		final Label l = (Label)obj;
-		
-		if (this.isBad == null) {
-			if (l.getIsBad() != null) {
-				return false;
-			}
-		} else if (!this.isBad.equals(l.getIsBad())) {
-			return false;
-		}
-		
-		if (this.description == null) {
-			if (l.getDescription() != null) {
-				return false;
-			}
-		} else if (!this.description.equals(l.getDescription())) {
-			return false;
-		}
-		
-		if (this.reasons == null) {
-			if (l.getReasons() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.reasons, l.getReasons())) {
-			return false;
-		}
-		
-		if (this.time == null) {
-			if (l.getTime() != null) {
-				return false;
-			}
-		} else if (!this.time.equals(l.getTime())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof Label)) {
+            return false;
+        }
+        
+        final Label l = (Label)obj;
+        
+        if (this.isBad == null) {
+            if (l.getIsBad() != null) {
+                return false;
+            }
+        } else if (!this.isBad.equals(l.getIsBad())) {
+            return false;
+        }
+        
+        if (this.description == null) {
+            if (l.getDescription() != null) {
+                return false;
+            }
+        } else if (!this.description.equals(l.getDescription())) {
+            return false;
+        }
+        
+        if (this.reasons == null) {
+            if (l.getReasons() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.reasons, l.getReasons())) {
+            return false;
+        }
+        
+        if (this.time == null) {
+            if (l.getTime() != null) {
+                return false;
+            }
+        } else if (!this.time.equals(l.getTime())) {
+            return false;
+        }
+        
+        return true;
+    }
+
 }

--- a/src/main/java/com/mcac0006/siftscience/score/domain/Reason.java
+++ b/src/main/java/com/mcac0006/siftscience/score/domain/Reason.java
@@ -74,32 +74,43 @@ public class Reason {
 	public final void setValue(String value) {
 		this.value = value;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
 
-		if (obj == null || !(obj instanceof Reason)) {
-			return false;
-		}
-		
-		final Reason e = (Reason)obj;
-		
-		if (this.name == null) {
-			if (e.getName() != null) {
-				return false;
-			}
-		} else if (!this.name.equals(e.getName())) {
-			return false;
-		}
-		
-		if (this.details == null) {
-			if (e.getDetails() != null) {
-				return false;
-			}
-		} else if (!this.details.equals(e.getDetails())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((details == null) ? 0 : details.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof Reason)) {
+            return false;
+        }
+        
+        final Reason e = (Reason)obj;
+        
+        if (this.name == null) {
+            if (e.getName() != null) {
+                return false;
+            }
+        } else if (!this.name.equals(e.getName())) {
+            return false;
+        }
+        
+        if (this.details == null) {
+            if (e.getDetails() != null) {
+                return false;
+            }
+        } else if (!this.details.equals(e.getDetails())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/score/domain/SiftScienceScore.java
+++ b/src/main/java/com/mcac0006/siftscience/score/domain/SiftScienceScore.java
@@ -107,64 +107,80 @@ public class SiftScienceScore {
 	public final void setErrorMessage(String errorMessage) {
 		this.errorMessage = errorMessage;
 	}
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((errorMessage == null) ? 0 : errorMessage.hashCode());
+        result = prime * result
+                + ((latestLabel == null) ? 0 : latestLabel.hashCode());
+        result = prime * result + Arrays.hashCode(reasons);
+        result = prime * result + ((score == null) ? 0 : score.hashCode());
+        result = prime * result + ((status == null) ? 0 : status.hashCode());
+        result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof SiftScienceScore)) {
+            return false;
+        }
+        
+        final SiftScienceScore e = (SiftScienceScore)obj;
+        
+        if (this.errorMessage == null) {
+            if (e.getErrorMessage() != null) {
+                return false;
+            }
+        } else if (!this.errorMessage.equals(e.getErrorMessage())) {
+            return false;
+        }
+        
+        if (this.latestLabel == null) {
+            if (e.getLatestLabel() != null) {
+                return false;
+            }
+        } else if (!this.latestLabel.equals(e.getLatestLabel())) {
+            return false;
+        }
+
+        if (this.reasons == null) {
+            if (e.getReasons() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(this.reasons, e.getReasons())) {
+            return false;
+        }
+        
+        if (this.score == null) {
+            if (e.getScore() != null) {
+                return false;
+            }
+        } else if (!this.score.equals(e.getScore())) {
+            return false;
+        }
+        
+        if (this.status == null) {
+            if (e.getStatus() != null) {
+                return false;
+            }
+        } else if (!this.status.equals(e.getStatus())) {
+            return false;
+        }
+        
+        if (this.userId == null) {
+            if (e.getUserId() != null) {
+                return false;
+            }
+        } else if (!this.userId.equals(e.getUserId())) {
+            return false;
+        }
+        
+        return true;
+    }
 	
-	@Override
-	public boolean equals(Object obj) {
-
-		if (obj == null || !(obj instanceof SiftScienceScore)) {
-			return false;
-		}
-		
-		final SiftScienceScore e = (SiftScienceScore)obj;
-		
-		if (this.errorMessage == null) {
-			if (e.getErrorMessage() != null) {
-				return false;
-			}
-		} else if (!this.errorMessage.equals(e.getErrorMessage())) {
-			return false;
-		}
-		
-		if (this.latestLabel == null) {
-			if (e.getLatestLabel() != null) {
-				return false;
-			}
-		} else if (!this.latestLabel.equals(e.getLatestLabel())) {
-			return false;
-		}
-
-		if (this.reasons == null) {
-			if (e.getReasons() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(this.reasons, e.getReasons())) {
-			return false;
-		}
-		
-		if (this.score == null) {
-			if (e.getScore() != null) {
-				return false;
-			}
-		} else if (!this.score.equals(e.getScore())) {
-			return false;
-		}
-		
-		if (this.status == null) {
-			if (e.getStatus() != null) {
-				return false;
-			}
-		} else if (!this.status.equals(e.getStatus())) {
-			return false;
-		}
-		
-		if (this.userId == null) {
-			if (e.getUserId() != null) {
-				return false;
-			}
-		} else if (!this.userId.equals(e.getUserId())) {
-			return false;
-		}
-		
-		return true;
-	}
 }

--- a/src/main/java/com/mcac0006/siftscience/types/Address.java
+++ b/src/main/java/com/mcac0006/siftscience/types/Address.java
@@ -125,80 +125,98 @@ public class Address {
 		this.phone = phone;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
 
-		if (obj == null || !(obj instanceof Address)) {
-			return false;
-		}
-		
-		final Address address = (Address)obj;
-		
-		if (this.addressLine1 == null) {
-			if (address.getAddressLine1() != null) {
-				return false;
-			}
-		} else if (!this.addressLine1.equals(address.getAddressLine1())) {
-			return false;
-		}
-		
-		if (this.addressLine2 == null) {
-			if (address.getAddressLine2() != null) {
-				return false;
-			}
-		} else if (!this.addressLine2.equals(address.getAddressLine2())) {
-			return false;
-		}
-		
-		if (this.city == null) {
-			if (address.getCity() != null) {
-				return false;
-			}
-		} else if (!this.city.equals(address.getCity())) {
-			return false;
-		}
-		
-		if (this.country == null) {
-			if (address.getCountry() != null) {
-				return false;
-			}
-		} else if (!this.country.equals(address.getCountry())) {
-			return false;
-		}
-		
-		if (this.name == null) {
-			if (address.getName() != null) {
-				return false;
-			}
-		} else if (!this.name.equals(address.getName())) {
-			return false;
-		}
-		
-		if (this.phone == null) {
-			if (address.getPhone() != null) {
-				return false;
-			}
-		} else if (!this.phone.equals(address.getPhone())) {
-			return false;
-		}
-		
-		if (this.region == null) {
-			if (address.getRegion() != null) {
-				return false;
-			}
-		} else if (!this.region.equals(address.getRegion())) {
-			return false;
-		}
-		
-		if (this.zipCode == null) {
-			if (address.getZipCode() != null) {
-				return false;
-			}
-		} else if (!this.zipCode.equals(address.getZipCode())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((addressLine1 == null) ? 0 : addressLine1.hashCode());
+        result = prime * result
+                + ((addressLine2 == null) ? 0 : addressLine2.hashCode());
+        result = prime * result + ((city == null) ? 0 : city.hashCode());
+        result = prime * result + ((country == null) ? 0 : country.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((phone == null) ? 0 : phone.hashCode());
+        result = prime * result + ((region == null) ? 0 : region.hashCode());
+        result = prime * result + ((zipCode == null) ? 0 : zipCode.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof Address)) {
+            return false;
+        }
+        
+        final Address address = (Address)obj;
+        
+        if (this.addressLine1 == null) {
+            if (address.getAddressLine1() != null) {
+                return false;
+            }
+        } else if (!this.addressLine1.equals(address.getAddressLine1())) {
+            return false;
+        }
+        
+        if (this.addressLine2 == null) {
+            if (address.getAddressLine2() != null) {
+                return false;
+            }
+        } else if (!this.addressLine2.equals(address.getAddressLine2())) {
+            return false;
+        }
+        
+        if (this.city == null) {
+            if (address.getCity() != null) {
+                return false;
+            }
+        } else if (!this.city.equals(address.getCity())) {
+            return false;
+        }
+        
+        if (this.country == null) {
+            if (address.getCountry() != null) {
+                return false;
+            }
+        } else if (!this.country.equals(address.getCountry())) {
+            return false;
+        }
+        
+        if (this.name == null) {
+            if (address.getName() != null) {
+                return false;
+            }
+        } else if (!this.name.equals(address.getName())) {
+            return false;
+        }
+        
+        if (this.phone == null) {
+            if (address.getPhone() != null) {
+                return false;
+            }
+        } else if (!this.phone.equals(address.getPhone())) {
+            return false;
+        }
+        
+        if (this.region == null) {
+            if (address.getRegion() != null) {
+                return false;
+            }
+        } else if (!this.region.equals(address.getRegion())) {
+            return false;
+        }
+        
+        if (this.zipCode == null) {
+            if (address.getZipCode() != null) {
+                return false;
+            }
+        } else if (!this.zipCode.equals(address.getZipCode())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/types/Item.java
+++ b/src/main/java/com/mcac0006/siftscience/types/Item.java
@@ -225,128 +225,155 @@ public class Item {
 		this.size = size;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
 
-		if (obj == null || !(obj instanceof Item)) {
-			return false;
-		}
-		
-		final Item item = (Item)obj;
-		
-		if (this.brand == null) {
-			if (item.getBrand() != null) {
-				return false;
-			}
-		} else if (!this.brand.equals(item.getBrand())) {
-			return false;
-		}
-		
-		if (this.category == null) {
-			if (item.getCategory() != null) {
-				return false;
-			}
-		} else if (!this.category.equals(item.getCategory())) {
-			return false;
-		}
-		
-		if (this.color == null) {
-			if (item.getColor() != null) {
-				return false;
-			}
-		} else if (!this.color.equals(item.getColor())) {
-			return false;
-		}
-		
-		if (this.currency == null) {
-			if (item.getCurrency() != null) {
-				return false;
-			}
-		} else if (!this.currency.equals(item.getCurrency())) {
-			return false;
-		}
-		
-		if (this.isbn == null) {
-			if (item.getIsbn() != null) {
-				return false;
-			}
-		} else if (!this.isbn.equals(item.getIsbn())) {
-			return false;
-		}
-		
-		if (this.itemId == null) {
-			if (item.getItemId() != null) {
-				return false;
-			}
-		} else if (!this.itemId.equals(item.getItemId())) {
-			return false;
-		}
-		
-		if (this.manufacturer == null) {
-			if (item.getManufacturer() != null) {
-				return false;
-			}
-		} else if (!this.manufacturer.equals(item.getManufacturer())) {
-			return false;
-		}
-		
-		if (this.price == null) {
-			if (item.getPrice() != null) {
-				return false;
-			}
-		} else if (!this.price.equals(item.getPrice())) {
-			return false;
-		}
-		
-		if (this.productTitle == null) {
-			if (item.getProductTitle() != null) {
-				return false;
-			}
-		} else if (!this.productTitle.equals(item.getProductTitle())) {
-			return false;
-		}
-		
-		if (this.quantity == null) {
-			if (item.getQuantity() != null) {
-				return false;
-			}
-		} else if (!this.quantity.equals(item.getQuantity())) {
-			return false;
-		}
-		
-		if (this.size == null) {
-			if (item.getSize() != null) {
-				return false;
-			}
-		} else if (!this.size.equals(item.getSize())) {
-			return false;
-		}
-		
-		if (this.sku == null) {
-			if (item.getSku() != null) {
-				return false;
-			}
-		} else if (!this.sku.equals(item.getSku())) {
-			return false;
-		}
-		
-		if (this.tags == null) {
-			if (item.getTags() != null) {
-				return false;
-			}
-		} else if (!Arrays.equals(tags, item.getTags())) {
-			return false;
-		}
-		
-		if (this.upc == null) {
-			if (item.getUpc() != null) {
-				return false;
-			}
-		} else if (!this.upc.equals(item.getUpc())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((brand == null) ? 0 : brand.hashCode());
+        result = prime * result
+                + ((category == null) ? 0 : category.hashCode());
+        result = prime * result + ((color == null) ? 0 : color.hashCode());
+        result = prime * result
+                + ((currency == null) ? 0 : currency.hashCode());
+        result = prime * result + ((isbn == null) ? 0 : isbn.hashCode());
+        result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+        result = prime * result
+                + ((manufacturer == null) ? 0 : manufacturer.hashCode());
+        result = prime * result + ((price == null) ? 0 : price.hashCode());
+        result = prime * result
+                + ((productTitle == null) ? 0 : productTitle.hashCode());
+        result = prime * result
+                + ((quantity == null) ? 0 : quantity.hashCode());
+        result = prime * result + ((size == null) ? 0 : size.hashCode());
+        result = prime * result + ((sku == null) ? 0 : sku.hashCode());
+        result = prime * result + Arrays.hashCode(tags);
+        result = prime * result + ((upc == null) ? 0 : upc.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof Item)) {
+            return false;
+        }
+        
+        final Item item = (Item)obj;
+        
+        if (this.brand == null) {
+            if (item.getBrand() != null) {
+                return false;
+            }
+        } else if (!this.brand.equals(item.getBrand())) {
+            return false;
+        }
+        
+        if (this.category == null) {
+            if (item.getCategory() != null) {
+                return false;
+            }
+        } else if (!this.category.equals(item.getCategory())) {
+            return false;
+        }
+        
+        if (this.color == null) {
+            if (item.getColor() != null) {
+                return false;
+            }
+        } else if (!this.color.equals(item.getColor())) {
+            return false;
+        }
+        
+        if (this.currency == null) {
+            if (item.getCurrency() != null) {
+                return false;
+            }
+        } else if (!this.currency.equals(item.getCurrency())) {
+            return false;
+        }
+        
+        if (this.isbn == null) {
+            if (item.getIsbn() != null) {
+                return false;
+            }
+        } else if (!this.isbn.equals(item.getIsbn())) {
+            return false;
+        }
+        
+        if (this.itemId == null) {
+            if (item.getItemId() != null) {
+                return false;
+            }
+        } else if (!this.itemId.equals(item.getItemId())) {
+            return false;
+        }
+        
+        if (this.manufacturer == null) {
+            if (item.getManufacturer() != null) {
+                return false;
+            }
+        } else if (!this.manufacturer.equals(item.getManufacturer())) {
+            return false;
+        }
+        
+        if (this.price == null) {
+            if (item.getPrice() != null) {
+                return false;
+            }
+        } else if (!this.price.equals(item.getPrice())) {
+            return false;
+        }
+        
+        if (this.productTitle == null) {
+            if (item.getProductTitle() != null) {
+                return false;
+            }
+        } else if (!this.productTitle.equals(item.getProductTitle())) {
+            return false;
+        }
+        
+        if (this.quantity == null) {
+            if (item.getQuantity() != null) {
+                return false;
+            }
+        } else if (!this.quantity.equals(item.getQuantity())) {
+            return false;
+        }
+        
+        if (this.size == null) {
+            if (item.getSize() != null) {
+                return false;
+            }
+        } else if (!this.size.equals(item.getSize())) {
+            return false;
+        }
+        
+        if (this.sku == null) {
+            if (item.getSku() != null) {
+                return false;
+            }
+        } else if (!this.sku.equals(item.getSku())) {
+            return false;
+        }
+        
+        if (this.tags == null) {
+            if (item.getTags() != null) {
+                return false;
+            }
+        } else if (!Arrays.equals(tags, item.getTags())) {
+            return false;
+        }
+        
+        if (this.upc == null) {
+            if (item.getUpc() != null) {
+                return false;
+            }
+        } else if (!this.upc.equals(item.getUpc())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }

--- a/src/main/java/com/mcac0006/siftscience/types/PaymentMethod.java
+++ b/src/main/java/com/mcac0006/siftscience/types/PaymentMethod.java
@@ -134,80 +134,96 @@ public class PaymentMethod {
 		this.routingNumber = routingNumber;
 		return this;
 	}
-	
-	@Override
-	public boolean equals(Object obj) {
 
-		if (obj == null || !(obj instanceof PaymentMethod)) {
-			return false;
-		}
-		
-		final PaymentMethod pm = (PaymentMethod)obj;
-		
-		if (this.aVSResultCode == null) {
-			if (pm.getAVSResultCode() != null) {
-				return false;
-			}
-		} else if (!this.aVSResultCode.equals(pm.getAVSResultCode())) {
-			return false;
-		}
-		
-		if (this.cardBIN == null) {
-			if (pm.getCardBIN() != null) {
-				return false;
-			}
-		} else if (!this.cardBIN.equals(pm.getCardBIN())) {
-			return false;
-		}
-		
-		if (this.cardLast4 == null) {
-			if (pm.getCardLast4() != null) {
-				return false;
-			}
-		} else if (!this.cardLast4.equals(pm.getCardLast4())) {
-			return false;
-		}
-		
-		if (this.cVVResultCode == null) {
-			if (pm.getCVVResultCode() != null) {
-				return false;
-			}
-		} else if (!this.cVVResultCode.equals(pm.getCVVResultCode())) {
-			return false;
-		}
-		
-		if (this.paymentGateway == null) {
-			if (pm.getPaymentGateway() != null) {
-				return false;
-			}
-		} else if (!this.paymentGateway.equals(pm.getPaymentGateway())) {
-			return false;
-		}
-		
-		if (this.paymentType == null) {
-			if (pm.getPaymentType() != null) {
-				return false;
-			}
-		} else if (!this.paymentType.equals(pm.getPaymentType())) {
-			return false;
-		}
-		
-		if (this.routingNumber == null) {
-			if (pm.getRoutingNumber() != null) {
-				return false;
-			}
-		} else if (!this.routingNumber.equals(pm.getRoutingNumber())) {
-			return false;
-		}
-		
-		if (this.verificationStatus == null) {
-			if (pm.getVerificationStatus() != null) {
-				return false;
-			}
-		} else if (!this.verificationStatus.equals(pm.getVerificationStatus())) {
-			return false;
-		}
-		
-		return true;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((aVSResultCode == null) ? 0 : aVSResultCode.hashCode());
+        result = prime * result + ((cVVResultCode == null) ? 0 : cVVResultCode.hashCode());
+        result = prime * result + ((cardBIN == null) ? 0 : cardBIN.hashCode());
+        result = prime * result + ((cardLast4 == null) ? 0 : cardLast4.hashCode());
+        result = prime * result + ((paymentGateway == null) ? 0 : paymentGateway.hashCode());
+        result = prime * result + ((paymentType == null) ? 0 : paymentType.hashCode());
+        result = prime * result + ((routingNumber == null) ? 0 : routingNumber.hashCode());
+        result = prime * result + ((verificationStatus == null) ? 0 : verificationStatus.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+
+        if (obj == null || !(obj instanceof PaymentMethod)) {
+            return false;
+        }
+        
+        final PaymentMethod pm = (PaymentMethod)obj;
+        
+        if (this.aVSResultCode == null) {
+            if (pm.getAVSResultCode() != null) {
+                return false;
+            }
+        } else if (!this.aVSResultCode.equals(pm.getAVSResultCode())) {
+            return false;
+        }
+        
+        if (this.cardBIN == null) {
+            if (pm.getCardBIN() != null) {
+                return false;
+            }
+        } else if (!this.cardBIN.equals(pm.getCardBIN())) {
+            return false;
+        }
+        
+        if (this.cardLast4 == null) {
+            if (pm.getCardLast4() != null) {
+                return false;
+            }
+        } else if (!this.cardLast4.equals(pm.getCardLast4())) {
+            return false;
+        }
+        
+        if (this.cVVResultCode == null) {
+            if (pm.getCVVResultCode() != null) {
+                return false;
+            }
+        } else if (!this.cVVResultCode.equals(pm.getCVVResultCode())) {
+            return false;
+        }
+        
+        if (this.paymentGateway == null) {
+            if (pm.getPaymentGateway() != null) {
+                return false;
+            }
+        } else if (!this.paymentGateway.equals(pm.getPaymentGateway())) {
+            return false;
+        }
+        
+        if (this.paymentType == null) {
+            if (pm.getPaymentType() != null) {
+                return false;
+            }
+        } else if (!this.paymentType.equals(pm.getPaymentType())) {
+            return false;
+        }
+        
+        if (this.routingNumber == null) {
+            if (pm.getRoutingNumber() != null) {
+                return false;
+            }
+        } else if (!this.routingNumber.equals(pm.getRoutingNumber())) {
+            return false;
+        }
+        
+        if (this.verificationStatus == null) {
+            if (pm.getVerificationStatus() != null) {
+                return false;
+            }
+        } else if (!this.verificationStatus.equals(pm.getVerificationStatus())) {
+            return false;
+        }
+        
+        return true;
+    }
+	
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1206- "equals(Object obj)" and "hashCode()" should be overridden in pairs
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1206

Please let me know if you have any questions.

Faisal Hameed