### PR TITLE
Code quality fix - Throws declarations should not be superfluous.

### DIFF
--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/DateDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/DateDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.Calendar;
 
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 
@@ -21,7 +20,7 @@ public class DateDeserializer extends JsonDeserializer<Calendar> {
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public Calendar deserialize(JsonParser parser, DeserializationContext context) throws IOException, JsonProcessingException {
+	public Calendar deserialize(JsonParser parser, DeserializationContext context) throws IOException {
 		final Calendar cal = Calendar.getInstance();
 		cal.setTimeInMillis(parser.getLongValue() * 1000);
 		return cal;

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/LoginStatusDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/LoginStatusDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -24,7 +23,7 @@ public class LoginStatusDeserializer extends JsonDeserializer<LoginStatus> {
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public LoginStatus deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public LoginStatus deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/PaymentGatewayDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/PaymentGatewayDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -24,7 +23,7 @@ public class PaymentGatewayDeserializer extends JsonDeserializer<PaymentGateway>
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public PaymentGateway deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public PaymentGateway deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/PaymentTypeDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/PaymentTypeDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -24,7 +23,7 @@ public class PaymentTypeDeserializer extends JsonDeserializer<PaymentType> {
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public PaymentType deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public PaymentType deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/ReasonDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/ReasonDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -24,7 +23,7 @@ public class ReasonDeserializer extends JsonDeserializer<Reason> {
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public Reason deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public Reason deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/SocialSignOnTypeDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/SocialSignOnTypeDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -25,7 +24,7 @@ public class SocialSignOnTypeDeserializer extends
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public SocialSignOnType deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public SocialSignOnType deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/SubmissionStatusDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/SubmissionStatusDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -25,7 +24,7 @@ public class SubmissionStatusDeserializer extends
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public SubmissionStatus deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public SubmissionStatus deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/TransactionStatusDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/TransactionStatusDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -25,7 +24,7 @@ public class TransactionStatusDeserializer extends JsonDeserializer<TransactionS
 	 */
 	@Override
 	public TransactionStatus deserialize(final JsonParser jp,
-									     final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+									     final DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/TransactionTypeDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/TransactionTypeDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -25,7 +24,7 @@ public class TransactionTypeDeserializer extends JsonDeserializer<TransactionTyp
 	 */
 	@Override
 	public TransactionType deserialize(final JsonParser jp,
-									   final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+									   final DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/deserializer/VerificationStatusDeserializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/deserializer/VerificationStatusDeserializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
@@ -25,7 +24,7 @@ public class VerificationStatusDeserializer extends
 	 * @see org.codehaus.jackson.map.JsonDeserializer#deserialize(org.codehaus.jackson.JsonParser, org.codehaus.jackson.map.DeserializationContext)
 	 */
 	@Override
-	public VerificationStatus deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+	public VerificationStatus deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 		
 		ObjectCodec oc = jp.getCodec();
         JsonNode node = oc.readTree(jp);

--- a/src/main/java/com/mcac0006/siftscience/types/serializer/DateSerializer.java
+++ b/src/main/java/com/mcac0006/siftscience/types/serializer/DateSerializer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.Calendar;
 
 import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.map.JsonSerializer;
 import org.codehaus.jackson.map.SerializerProvider;
 
@@ -18,7 +17,7 @@ import org.codehaus.jackson.map.SerializerProvider;
 public class DateSerializer extends JsonSerializer<Calendar> {
 
 	@Override
-	public void serialize(Calendar date, JsonGenerator gen, SerializerProvider pro) throws IOException, JsonProcessingException {
+	public void serialize(Calendar date, JsonGenerator gen, SerializerProvider pro) throws IOException {
 		gen.writeNumber(date.getTimeInMillis() / 1000);
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:RedundantThrowsDeclarationCheck- Throws declarations should not be superfluous.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck

Please let me know if you have any questions.

Faisal Hameed