### PR TITLE
Code quality fix - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".

### DIFF
--- a/src/main/java/com/mcac0006/siftscience/event/domain/AddItemToCart.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/AddItemToCart.java
@@ -85,7 +85,7 @@ public class AddItemToCart extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof AddItemToCart)) {
+		if (!(obj instanceof AddItemToCart)) {
 			return false;
 		}
 		

--- a/src/main/java/com/mcac0006/siftscience/event/domain/LinkSessionToUser.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/LinkSessionToUser.java
@@ -58,7 +58,7 @@ public class LinkSessionToUser extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof LinkSessionToUser)) {
+		if (!(obj instanceof LinkSessionToUser)) {
 			return false;
 		}
 		

--- a/src/main/java/com/mcac0006/siftscience/event/domain/Login.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/Login.java
@@ -81,7 +81,7 @@ public class Login extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof Login)) {
+		if (!(obj instanceof Login)) {
 			return false;
 		}
 		

--- a/src/main/java/com/mcac0006/siftscience/event/domain/Logout.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/Logout.java
@@ -44,7 +44,7 @@ public class Logout extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof Logout)) {
+		if (!(obj instanceof Logout)) {
 			return false;
 		}
 		

--- a/src/main/java/com/mcac0006/siftscience/event/domain/RemoveItemFromCart.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/RemoveItemFromCart.java
@@ -81,7 +81,7 @@ public class RemoveItemFromCart extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof RemoveItemFromCart)) {
+		if (!(obj instanceof RemoveItemFromCart)) {
 			return false;
 		}
 		

--- a/src/main/java/com/mcac0006/siftscience/event/domain/SendMessage.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/SendMessage.java
@@ -112,7 +112,7 @@ public class SendMessage extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof SendMessage)) {
+		if (!(obj instanceof SendMessage)) {
 			return false;
 		}
 		

--- a/src/main/java/com/mcac0006/siftscience/event/domain/SubmitReview.java
+++ b/src/main/java/com/mcac0006/siftscience/event/domain/SubmitReview.java
@@ -137,7 +137,7 @@ public class SubmitReview extends Event {
 			return false;
 		}
 
-		if (obj == null || !(obj instanceof SubmitReview)) {
+		if (!(obj instanceof SubmitReview)) {
 			return false;
 		}
 		


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.

Faisal Hameed